### PR TITLE
feat: use goroutines

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,5 +115,5 @@ Add the target to your `scrape_configs` in your `prometheus.yml` file of your Pr
 scrape_configs:
   - job_name: 'qbittorrent'
     static_configs:
-      - targets: [ '<your_ip_adress>:8090' ]
+      - targets: [ '<your_ip_address>:8090' ]
 ```

--- a/src/init.go
+++ b/src/init.go
@@ -86,7 +86,7 @@ func loadenv() {
 	qbitUsername := getEnv("QBITTORRENT_USERNAME", "admin", true, "Qbittorrent username is not set. Using default username")
 	qbitPassword := getEnv("QBITTORRENT_PASSWORD", "adminadmin", true, "Qbittorrent password is not set. Using default password")
 	qbitURL := getEnv("QBITTORRENT_BASE_URL", "http://localhost:8080", true, "Qbittorrent base_url is not set. Using default base_url")
-	exporterPort := getEnv("EXPORTER_PORT", "8090", false, "")
+	exporterPort := getEnv("EXPORTER_PORT", strconv.Itoa(DEFAULTPORT), false, "")
 
 	num, err := strconv.Atoi(exporterPort)
 


### PR DESCRIPTION
Got a headache with goroutines; the exporter makes a first api call to the version endpoint which always return the qbittorrent version so very little data, if the cookie has changed, it tries to get the qbitversion with a new cookie, then it fetches the data from the 3 other endpoints which returns a lot more data (and where goroutines makes sense). The only use case I can think of is when the cookie is invalidated between the call to get qbittorrent version and the 3 other calls, which is very unlikely.