### PR TITLE
fix: memory leak when qBittorrent is paused

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ yarn-debug.log*
 yarn-error.log*
 
 .env
+*.pprof

--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ Docker compressed size is ~10 MB.
 | `-e QBITTORRENT_USERNAME` | qBittorrent username                                     | `admin`                 |
 | `-e QBITTORRENT_PASSWORD` | qBittorrent password                                     | `adminadmin`            |
 | `-e QBITTORRENT_BASE_URL` | qBittorrent base URL                                     | `http://localhost:8090` |
+| `-e QBITTORRENT_TIMEOUT`  | duration before ending a request to qBittorrent          | `30`                    |
 |    `-e EXPORTER_PORT`     | qbittorrent export port (optional)                       | `8090`                  |
 |   `-e DISABLE_TRACKER`    | get tracker infos (need an API request for each tracker) | `false`                 |
 |      `-e LOG_LEVEL`       | App log level (`DEBUG`, `INFO`, `WARN` and `ERROR`)      | `INFO`                  |
@@ -139,7 +140,7 @@ Add the target to your `scrape_configs` in your `prometheus.yml` file of your Pr
 
 ```yaml
 scrape_configs:
-  - job_name: 'qbittorrent'
+  - job_name: "qbittorrent"
     static_configs:
-      - targets: [ '<your_ip_address>:8090' ]
+      - targets: ["<your_ip_address>:8090"]
 ```

--- a/src/app/app.go
+++ b/src/app/app.go
@@ -1,19 +1,23 @@
 package app
 
-import "strings"
-
-var (
-	Port            int
-	ShouldShowError bool
-	DisableTracker  bool
-	LogLevel        string
-	BaseUrl         string
-	Cookie          string
-	Username        string
-	Password        string
+import (
+	"strings"
+	"time"
 )
 
-func SetVar(port int, disableTracker bool, loglevel string, baseUrl string, username string, password string) {
+var (
+	QbittorrentTimeout time.Duration
+	Port               int
+	ShouldShowError    bool
+	DisableTracker     bool
+	LogLevel           string
+	BaseUrl            string
+	Cookie             string
+	Username           string
+	Password           string
+)
+
+func SetVar(port int, disableTracker bool, loglevel string, baseUrl string, username string, password string, qbittorrentTimeout int) {
 	Port = port
 	ShouldShowError = true
 	DisableTracker = disableTracker
@@ -21,6 +25,7 @@ func SetVar(port int, disableTracker bool, loglevel string, baseUrl string, user
 	BaseUrl = baseUrl
 	Username = username
 	Password = password
+	QbittorrentTimeout = time.Duration(qbittorrentTimeout)
 }
 
 func GetPasswordMasked() string {

--- a/src/prometheus/prometheus_test.go
+++ b/src/prometheus/prometheus_test.go
@@ -6,7 +6,7 @@ import (
 )
 
 func TestMain(t *testing.T) {
-	app.SetVar(0, false, "", "http://localhost:8080", "admin", "adminadmin")
+	app.SetVar(0, false, "", "http://localhost:8080", "admin", "adminadmin", 30)
 	result := app.GetPasswordMasked()
 
 	if !isValidMaskedPassword(result) {


### PR DESCRIPTION
This PR adds multiple improvements:
- Add a timeout for requests to qBittorrent which can be tweaked with the `QBITTORRENT_TIMEOUT` env
- Return error 503 if qBittorrent is down and run GC
- Add more debug logs