### PR TITLE
test: more tests for prometheus.go (part 2)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,9 @@ test-count:
 	cd src && go test ./... -v | grep -c RUN
 
 test-coverage:
+	cd src && go test ./... -cover
+
+test-coverage-web:
 	cd src && go test ./... -coverprofile=cover.out && go tool cover -html=cover.out && rm cover.out
 
 update: 

--- a/src/api/qbittorrent.go
+++ b/src/api/qbittorrent.go
@@ -42,8 +42,8 @@ type Preferences struct {
 
 type MainData struct {
 	CategoryMap map[string]Category `json:"categories"`
-	ServerState ServerState
-	Tags        []string `json:"tags"`
+	ServerState ServerState         `json:"server_state"`
+	Tags        []string            `json:"tags"`
 }
 
 type ServerState struct {

--- a/src/app/app_test.go
+++ b/src/app/app_test.go
@@ -1,6 +1,7 @@
 package app
 
 import (
+	"strings"
 	"testing"
 )
 
@@ -94,5 +95,38 @@ func TestGetFeaturesEnabled(t *testing.T) {
 				t.Errorf("expected %s, got %s", test.expectedOutput, result)
 			}
 		})
+	}
+}
+
+func TestEnvSetToTrue(t *testing.T) {
+	tests := []struct {
+		input  string
+		output bool
+	}{
+		{"true", true},
+		{"TRUE", true},
+		{"False", false},
+		{"false", false},
+		{"1", false},
+		{"0", false},
+		{"", false},
+		{"randomstring", false},
+	}
+
+	for _, test := range tests {
+		got := envSetToTrue(test.input)
+		if got != test.output {
+			t.Errorf("envSetToTrue(%q) = %v; want %v", test.input, got, test.output)
+		}
+	}
+}
+
+func TestGetPasswordMasked(t *testing.T) {
+	QBittorrent.Password = "mysecretpassword"
+	expected := strings.Repeat("*", len(QBittorrent.Password))
+	got := GetPasswordMasked()
+
+	if got != expected {
+		t.Errorf("GetPasswordMasked() = %q; want %q", got, expected)
 	}
 }

--- a/src/prometheus/prometheus.go
+++ b/src/prometheus/prometheus.go
@@ -317,6 +317,7 @@ func Trackers(result []*API.Trackers, r *prometheus.Registry) {
 				metrics[QbittorrentTrackerSeeders].With(labels).Set((float64(tracker.NumSeeds)))
 				metrics[QbittorrentTrackerPeers].With(labels).Set((float64(tracker.NumPeers)))
 				metrics[QbittorrentTrackerStatus].With(labels).Set((float64(tracker.Status)))
+				metrics[QbittorrentTrackerTier].With(labels).Set((float64(tier)))
 
 				if app.Exporter.Feature.EnableHighCardinality {
 					qbittorrentTrackerInfoLabels := prometheus.Labels{
@@ -342,7 +343,7 @@ func MainData(result *API.MainData, r *prometheus.Registry) {
 	globalratio, err := strconv.ParseFloat((*result).ServerState.GlobalRatio, 64)
 
 	if err != nil {
-		logger.Log.Warn("error to convert ratio")
+		logger.Log.Warn(fmt.Sprintf("error to convert ratio \"%s\"", (*result).ServerState.GlobalRatio))
 	} else {
 		qbittorrentGlobalRatio := prometheus.NewGauge(prometheus.GaugeOpts{
 			Name: createMetricName(metricNameGlobal, "ratio"),


### PR DESCRIPTION
Tests (almost) all functions in prometheus.go. Fixed one missing metric (`qbittorrent_tracker_tier`)