### PR TITLE
ci: add `staticcheck` linter

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,3 +50,11 @@ jobs:
         with:
           version: v1.63.4
           working-directory: src
+
+      - name: staticcheck
+        uses: dominikh/staticcheck-action@v1
+        if: ${{ !cancelled() }}
+        with:
+          version: latest
+          install-go: false
+          working-directory: src

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,17 +44,17 @@ jobs:
         with:
           dockerfile: Dockerfile
 
-      - name: golangci-lint
-        uses: golangci/golangci-lint-action@v6
-        if: ${{ !cancelled() }}
-        with:
-          version: v1.63.4
-          working-directory: src
-
       - name: staticcheck
         uses: dominikh/staticcheck-action@v1
         if: ${{ !cancelled() }}
         with:
           version: latest
           install-go: false
+          working-directory: src
+
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v6
+        if: ${{ !cancelled() }}
+        with:
+          version: v1.63.4
           working-directory: src

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,7 +48,7 @@ jobs:
         uses: dominikh/staticcheck-action@v1
         if: ${{ !cancelled() }}
         with:
-          version: latest
+          version: v0.5.1
           install-go: false
           working-directory: src
 

--- a/Makefile
+++ b/Makefile
@@ -1,17 +1,18 @@
-build: 
+build:
 	cd src && go build -o ../qbittorrent-exporter.out .
 
-dev : 
+dev:
 	cd src && go run .
 
-dev-env : 
+dev-env:
 	cd src && go run . -e
 
-format : 
+format:
 	cd src && test -z $(gofmt -l .)
 
-lint: 
+lint:
 	docker run --rm -v ./src:/app -w /app golangci/golangci-lint:latest golangci-lint run -v
+	docker run --rm -v ./src:/app -w /app golang:alpine sh -c 'go install honnef.co/go/tools/cmd/staticcheck@latest && staticcheck ./...'
 
 test:
 	cd src && go test -v ./... | \
@@ -27,5 +28,5 @@ test-coverage:
 test-coverage-web:
 	cd src && go test ./... -coverprofile=cover.out && go tool cover -html=cover.out && rm cover.out
 
-update: 
+update:
 	cd src && go get -u . && go mod tidy

--- a/src/qbit/auth.go
+++ b/src/qbit/auth.go
@@ -41,7 +41,7 @@ func Auth() error {
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		err := fmt.Errorf("Authentication failed, status code: %d", resp.StatusCode)
+		err := fmt.Errorf("authentication failed, status code: %d", resp.StatusCode)
 		if resp.StatusCode == http.StatusForbidden && app.QBittorrent.Cookie == nil {
 			panic(fmt.Sprintf("%s. qBittorrent has probably banned your IP", err.Error()))
 		}

--- a/src/qbit/auth_test.go
+++ b/src/qbit/auth_test.go
@@ -18,8 +18,7 @@ import (
 
 var buff = &bytes.Buffer{}
 
-const tenMs = time.Duration(10 * time.Millisecond)
-const fiftyMs = time.Duration(50 * time.Millisecond)
+const defaultTimeout = 10 * time.Millisecond
 
 func init() {
 	logger.Log = &logger.Logger{Logger: slog.New(slog.NewTextHandler(buff, &slog.HandlerOptions{}))}
@@ -44,7 +43,7 @@ func TestAuthSuccess(t *testing.T) {
 	app.QBittorrent.BaseUrl = ts.URL
 	app.QBittorrent.Username = "testuser"
 	app.QBittorrent.Password = "testpass"
-	app.QBittorrent.Timeout = tenMs
+	app.QBittorrent.Timeout = defaultTimeout
 
 	err := Auth()
 
@@ -71,7 +70,7 @@ func TestAuthFail(t *testing.T) {
 	app.QBittorrent.BaseUrl = ts.URL
 	app.QBittorrent.Username = "wronguser"
 	app.QBittorrent.Password = "wrongpass"
-	app.QBittorrent.Timeout = tenMs
+	app.QBittorrent.Timeout = defaultTimeout
 
 	defer func() {
 		if r := recover(); r == nil {
@@ -96,7 +95,7 @@ func TestAuthInvalidUrl(t *testing.T) {
 	app.QBittorrent.BaseUrl = ts.URL + "//"
 	app.QBittorrent.Username = ""
 	app.QBittorrent.Password = ""
-	app.QBittorrent.Timeout = tenMs
+	app.QBittorrent.Timeout = defaultTimeout
 
 	defer func() {
 		if r := recover(); r == nil {
@@ -110,14 +109,14 @@ func TestAuthInvalidUrl(t *testing.T) {
 func TestAuthTimeout(t *testing.T) {
 	t.Cleanup(resetState)
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		time.Sleep(fiftyMs)
+		time.Sleep(defaultTimeout * 5)
 	}))
 	defer ts.Close()
 
 	app.QBittorrent.BaseUrl = ts.URL
 	app.QBittorrent.Username = ""
 	app.QBittorrent.Password = ""
-	app.QBittorrent.Timeout = tenMs
+	app.QBittorrent.Timeout = defaultTimeout
 	_ = Auth()
 
 	if !strings.Contains(buff.String(), API.QbittorrentTimeOut) {
@@ -135,7 +134,7 @@ func TestUnknownStatusCode(t *testing.T) {
 	app.QBittorrent.BaseUrl = ts.URL
 	app.QBittorrent.Username = ""
 	app.QBittorrent.Password = ""
-	app.QBittorrent.Timeout = tenMs
+	app.QBittorrent.Timeout = defaultTimeout
 	_ = Auth()
 
 	if !strings.Contains(buff.String(), strconv.Itoa(http.StatusCreated)) {


### PR DESCRIPTION
The `staticcheck` linter is not included in `golangci-lint` (see https://golangci-lint.run/usage/linters/#enabled-by-default) and VSCode displayed some warnings that the current linting setup didn't catch.

```txt
qbit/auth.go:44:10: error strings should not be capitalized (ST1005)
qbit/auth_test.go:21:7: var tenMs is of type time.Duration; don't use unit-specific suffix "Ms" (ST1011)
qbit/auth_test.go:22:7: var fiftyMs is of type time.Duration; don't use unit-specific suffix "Ms" (ST1011)
```