### PR TITLE
feat: new metrics

### DIFF
--- a/.env.exemple
+++ b/.env.exemple
@@ -9,6 +9,7 @@ QBITTORRENT_TIMEOUT=
 
 ## features
 DISABLE_TRACKER=false
+ENABLE_INCREASED_CARDINALITY=false
 ENABLE_HIGH_CARDINALITY=false
 
 ## experimental features

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,17 +44,10 @@ jobs:
         with:
           dockerfile: Dockerfile
 
-      - name: staticcheck
-        uses: dominikh/staticcheck-action@v1
-        if: ${{ !cancelled() }}
-        with:
-          version: v0.6.1
-          install-go: false
-          working-directory: src
-
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v7
         if: ${{ !cancelled() }}
         with:
+          args: --config=.golangci.yml --issues-exit-code=0
           version: v2.0.0
           working-directory: src

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,6 @@ format:
 
 lint:
 	docker run --rm -v ./src:/app -w /app golangci/golangci-lint:latest golangci-lint run -v
-	docker run --rm -v ./src:/app -w /app golang:alpine sh -c 'go install honnef.co/go/tools/cmd/staticcheck@latest && staticcheck ./...'
 
 test:
 	cd src && go test -v ./... | \

--- a/README.md
+++ b/README.md
@@ -116,28 +116,29 @@ Docker compressed size is ~10 MB.
 
 ### Environment variables
 
-| Parameter                            | Function                                                                                | Default Value           |
-|--------------------------------------|-----------------------------------------------------------------------------------------|-------------------------|
-| `-p 8090`                            | Webservice port                                                                         |                         |
-| `-e QBITTORRENT_USERNAME`            | qBittorrent username                                                                    | `admin`                 |
-| `-e QBITTORRENT_PASSWORD`            | qBittorrent password                                                                    | `adminadmin`            |
-| `-e QBITTORRENT_BASE_URL`            | qBittorrent base URL                                                                    | `http://localhost:8090` |
-| `-e QBITTORRENT_BASIC_AUTH_USERNAME` | Send basic auth username request header (only if username or password are set)          |                         |
-| `-e QBITTORRENT_BASIC_AUTH_PASSWORD` | Send basic auth password request header (only if username or password are set)          |                         |
-| `-e QBITTORRENT_TIMEOUT`             | Duration before ending a request to qBittorrent                                         | `30`                    |
-| `-e EXPORTER_PORT`                   | qBittorrent export port (optional)                                                      | `8090`                  |
-| `-e EXPORTER_BASIC_AUTH_USERNAME`    | Use basic auth (only if username and password are set)                                  |                         |
-| `-e EXPORTER_BASIC_AUTH_PASSWORD`    | Use basic auth (only if username and password are set)                                  |                         |
-| `-e LOG_LEVEL`                       | App log level (`DEBUG`, `INFO`, `WARN`, `ERROR`)                                        | `INFO`                  |
-| `-e ENABLE_TRACKER`                  | Get tracker info                                                                        | `true`                  |
-| `-e ENABLE_HIGH_CARDINALITY`         | Enable high cardinality metric (`qbittorrent_torrent_info`, `qbittorrent_tracker_info`) | `false`                 |
-| `-e ENABLE_LABEL_WITH_HASH`          | **[EXPERIMENTAL]** Add the torrent hash to `qbittorrent_torrent_*` metrics label        | `false`                 |
-| `-e EXPORTER_URL`                    | The URL shown in the logs when starting the exporter                                    |                         |
-| `-e EXPORTER_PATH`                   | The path where the metrics are exposed                                                  | `/metrics`              |
-| `-e DANGEROUS_SHOW_PASSWORD`         | Show the qBittorrent password in logs when starting the exporter                        | `false`                 |
-| `-e CERTIFICATE_AUTHORITY_PATH`      | Path to a CA (`.crt`) used to verify the qBittorrent TLS certificate                    |                         |
-| `-e INSECURE_SKIP_VERIFY`            | Don't validate the TLS certificate presented by qBittorrent                             | `false`                 |
-| `-e MIN_TLS_VERSION`                 | Only connect to qBittorrent if it supports at least this TLS version                    | `TLS_1_3`               |
+| Parameter                            | Function                                                                                                                     | Default Value           |
+| ------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------- | ----------------------- |
+| `-p 8090`                            | Webservice port                                                                                                              |                         |
+| `-e QBITTORRENT_USERNAME`            | qBittorrent username                                                                                                         | `admin`                 |
+| `-e QBITTORRENT_PASSWORD`            | qBittorrent password                                                                                                         | `adminadmin`            |
+| `-e QBITTORRENT_BASE_URL`            | qBittorrent base URL                                                                                                         | `http://localhost:8090` |
+| `-e QBITTORRENT_BASIC_AUTH_USERNAME` | Send basic auth username request header (only if username or password are set)                                               |                         |
+| `-e QBITTORRENT_BASIC_AUTH_PASSWORD` | Send basic auth password request header (only if username or password are set)                                               |                         |
+| `-e QBITTORRENT_TIMEOUT`             | Duration before ending a request to qBittorrent                                                                              | `30`                    |
+| `-e EXPORTER_PORT`                   | qBittorrent export port (optional)                                                                                           | `8090`                  |
+| `-e EXPORTER_BASIC_AUTH_USERNAME`    | Use basic auth (only if username and password are set)                                                                       |                         |
+| `-e EXPORTER_BASIC_AUTH_PASSWORD`    | Use basic auth (only if username and password are set)                                                                       |                         |
+| `-e LOG_LEVEL`                       | App log level (`DEBUG`, `INFO`, `WARN`, `ERROR`)                                                                             | `INFO`                  |
+| `-e ENABLE_TRACKER`                  | Get tracker info                                                                                                             | `true`                  |
+| `-e ENABLE_HIGH_CARDINALITY`         | Enable high cardinality metric (`qbittorrent_torrent_info`, `qbittorrent_tracker_info`)                                      | `false`                 |
+| `-e ENABLE_LABEL_WITH_HASH`          | **[EXPERIMENTAL]** Add the torrent hash to `qbittorrent_torrent_*` metrics label                                             | `false`                 |
+| `-e EXPORTER_URL`                    | The URL shown in the logs when starting the exporter                                                                         |                         |
+| `-e EXPORTER_PATH`                   | The path where the metrics are exposed                                                                                       | `/metrics`              |
+| `-e DANGEROUS_SHOW_PASSWORD`         | Show the qBittorrent password in logs when starting the exporter                                                             | `false`                 |
+| `-e CERTIFICATE_AUTHORITY_PATH`      | Path to a CA (`.crt`) used to verify the qBittorrent TLS certificate                                                         |                         |
+| `-e INSECURE_SKIP_VERIFY`            | Don't validate the TLS certificate presented by qBittorrent                                                                  | `false`                 |
+| `-e MIN_TLS_VERSION`                 | Only connect to qBittorrent if it supports at least this TLS version                                                         | `TLS_1_3`               |
+| `-e ENABLE_INCREASED_CARDINALITY`    | Enable high cardinality metric (`qbittorrent_torrent_save_path`, `qbittorrent_torrent_state`, `qbittorrent_torrent_comment`) | `false`                 |
 
 ### Arguments
 

--- a/src/.golangci.yml
+++ b/src/.golangci.yml
@@ -1,0 +1,10 @@
+linters:
+  enable:
+    - staticcheck
+    - errcheck
+    - govet
+    - unused
+    - gocritic
+    - ineffassign
+    - bodyclose
+version: "2"

--- a/src/api/qbittorrent.go
+++ b/src/api/qbittorrent.go
@@ -8,7 +8,10 @@ const ErrorConnect string = "Can't connect to qBittorrent"
 
 type Info []struct {
 	AmountLeft        int64   `json:"amount_left"`
+	AddedOn           int64   `json:"added_on"`
 	Category          string  `json:"category"`
+	Comment           string  `json:"comment"`
+	CompletedOn       int64   `json:"completed_on"`
 	Dlspeed           int64   `json:"dlspeed"`
 	Downloaded        int64   `json:"downloaded"`
 	DownloadedSession int64   `json:"downloaded_session"`
@@ -20,6 +23,7 @@ type Info []struct {
 	NumSeeds          int64   `json:"num_seeds"`
 	Progress          float64 `json:"progress"`
 	Ratio             float64 `json:"ratio"`
+	SavePath          string  `json:"save_path"`
 	Size              int64   `json:"size"`
 	State             string  `json:"state"`
 	Tags              string  `json:"tags"`

--- a/src/api/qbittorrent.go
+++ b/src/api/qbittorrent.go
@@ -11,7 +11,7 @@ type Info []struct {
 	AddedOn           int64   `json:"added_on"`
 	Category          string  `json:"category"`
 	Comment           string  `json:"comment"`
-	CompletedOn       int64   `json:"completed_on"`
+	CompletionOn      int64   `json:"completion_on"`
 	Dlspeed           int64   `json:"dlspeed"`
 	Downloaded        int64   `json:"downloaded"`
 	DownloadedSession int64   `json:"downloaded_session"`

--- a/src/app/app.go
+++ b/src/app/app.go
@@ -60,9 +60,10 @@ type ExperimentalFeatures struct {
 }
 
 type Features struct {
-	EnableHighCardinality bool
-	EnableTracker         bool
-	ShowPassword          bool
+	EnableIncreasedCardinality bool
+	EnableHighCardinality      bool
+	EnableTracker              bool
+	ShowPassword               bool
 }
 
 func LoadEnv() {
@@ -114,6 +115,7 @@ func LoadEnv() {
 	timeoutDurationEnv, _ := getEnv(defaultTimeout)
 	enableTracker, _ := getEnv(defaultDisableTracker)
 	enableHighCardinality, _ := getEnv(defaultHighCardinality)
+	enableIncreasedCardinality, _ := getEnv(defaultIncreasedCardinality)
 	labelWithHash, _ := getEnv(defaultLabelWithHash)
 	exporterUrlEnv := getOptionalEnv(defaultExporterURL)
 	exporterPath, _ := getEnv(defaultExporterPathEnv)
@@ -215,8 +217,6 @@ func LoadEnv() {
 		logger.Log.Trace("Not using basic auth to protect the exporter instance")
 	}
 
-	logger.Log.Info(fmt.Sprintf("Features enabled: %s", getFeaturesEnabled()))
-
 	HttpClient = http.Client{
 		Transport: &http.Transport{
 			TLSClientConfig: &tls.Config{
@@ -240,9 +240,10 @@ func LoadEnv() {
 
 	Exporter = ExporterSettings{
 		Features: Features{
-			EnableHighCardinality: envSetToTrue(enableHighCardinality),
-			EnableTracker:         envSetToTrue(enableTracker),
-			ShowPassword:          showPassword,
+			EnableIncreasedCardinality: envSetToTrue(enableIncreasedCardinality),
+			EnableHighCardinality:      envSetToTrue(enableHighCardinality),
+			EnableTracker:              envSetToTrue(enableTracker),
+			ShowPassword:               showPassword,
 		},
 		ExperimentalFeatures: ExperimentalFeatures{
 			EnableLabelWithHash: envSetToTrue(labelWithHash),
@@ -253,6 +254,7 @@ func LoadEnv() {
 		BasicAuth: exporterBasicAuth,
 	}
 
+	logger.Log.Info(fmt.Sprintf("Features enabled: %s", getFeaturesEnabled()))
 }
 
 func getBasicAuth(basicAuthUsername *string, basicAuthPassword *string, defaultBasicAuth string, defaultBasicPassword string) *BasicAuth {
@@ -298,6 +300,11 @@ func getFeaturesEnabled() string {
 
 	if Exporter.Features.EnableHighCardinality {
 		features += "High cardinality"
+	}
+
+	if Exporter.Features.EnableIncreasedCardinality {
+		addComma()
+		features += "Increased cardinality"
 	}
 
 	if Exporter.Features.EnableTracker {

--- a/src/app/default.go
+++ b/src/app/default.go
@@ -48,6 +48,12 @@ var defaultHighCardinality = Env{
 	Help:         "",
 }
 
+var defaultIncreasedCardinality = Env{
+	Key:          "ENABLE_INCREASED_CARDINALITY",
+	DefaultValue: "false",
+	Help:         "",
+}
+
 var defaultLabelWithHash = Env{
 	Key:          "ENABLE_LABEL_WITH_HASH",
 	DefaultValue: "false",

--- a/src/go.mod
+++ b/src/go.mod
@@ -16,5 +16,5 @@ require (
 	github.com/prometheus/common v0.63.0 // indirect
 	github.com/prometheus/procfs v0.16.0 // indirect
 	golang.org/x/sys v0.31.0 // indirect
-	google.golang.org/protobuf v1.36.5 // indirect
+	google.golang.org/protobuf v1.36.6 // indirect
 )

--- a/src/go.sum
+++ b/src/go.sum
@@ -28,7 +28,7 @@ github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOf
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 golang.org/x/sys v0.31.0 h1:ioabZlmFYtWhL+TRYpcnNlLwhyxaM9kWTDEmfnprqik=
 golang.org/x/sys v0.31.0/go.mod h1:BJP2sWEmIv4KK5OTEluFJCKSidICx8ciO85XgH3Ak8k=
-google.golang.org/protobuf v1.36.5 h1:tPhr+woSbjfYvY6/GPufUoYizxw1cF/yFoxJ2fmpwlM=
-google.golang.org/protobuf v1.36.5/go.mod h1:9fA7Ob0pmnwhb644+1+CVWFRbNajQ6iRojtC/QF5bRE=
+google.golang.org/protobuf v1.36.6 h1:z1NpPI8ku2WgiWnf+t9wTPsn6eP1L7ksHUlkfLvd9xY=
+google.golang.org/protobuf v1.36.6/go.mod h1:jduwjTPXsFjZGTmRluh+L6NjiWu7pchiJ2/5YcXBHnY=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/src/prometheus/prometheus.go
+++ b/src/prometheus/prometheus.go
@@ -45,7 +45,7 @@ const (
 	torrentLabelAmountLeftBytes        string = "amount_left_bytes"
 	torrentLabelCategory               string = "category"
 	torrentLabelComment                string = "comment"
-	torrentLabelCompletedOn            string = "completed_on"
+	torrentLabelCompletionOn           string = "completed_on"
 	torrentLabelConnectionStatus       string = "connection_status"
 	torrentLabelDlSpeed                string = "dl_speed"
 	torrentLabelDownloadedSession      string = "downloaded_session"
@@ -168,7 +168,7 @@ func Torrent(result *API.Info, webUIVersion *string, r *prometheus.Registry) {
 		torrentState             = createMetricName(metricNameTorrent, torrentLabelState)
 		torrentSavePath          = createMetricName(metricNameTorrent, torrentLabelSavePath)
 		torrentAddedOn           = createMetricName(metricNameTorrent, torrentLabelAddedOn)
-		torrentCompletedOn       = createMetricName(metricNameTorrent, torrentLabelCompletedOn)
+		torrentCompletionOn      = createMetricName(metricNameTorrent, torrentLabelCompletionOn)
 	)
 
 	labels := []string{labelName}
@@ -201,13 +201,13 @@ func Torrent(result *API.Info, webUIVersion *string, r *prometheus.Registry) {
 		{&torrentState, nil, "State this torrent", &labelsWithState},
 		{&torrentSavePath, nil, "Save path for this torrent", &labelsWithSavePath},
 		{&torrentAddedOn, nil, "Timestamp when this torrent was added", &labels},
-		{&torrentCompletedOn, nil, "Timestamp when this torrent was completed", &labels},
+		{&torrentCompletionOn, nil, "Timestamp when this torrent was completed", &labels},
 	}
 
 	metrics := registerGauge(&gauges, r)
 
 	if app.Exporter.Features.EnableHighCardinality {
-		torrentInfoLabels := []string{labelName, torrentLabelCategory, torrentLabelState, torrentLabelSize, torrentLabelProgress, labelSeeders, torrentLabelLeechers, torrentLabelDlSpeed, torrentLabelUpSpeed, torrentLabelAmountLeft, torrentLabelTimeActive, torrentLabelEta, torrentLabelUploaded, torrentLabelUploadedSession, labelDownloaded, torrentLabelDownloadedSession, torrentLabelMaxRatio, torrentLabelRatio, torrentLabelTracker, torrentLabelAddedOn, torrentLabelComment, torrentLabelCompletedOn, torrentLabelSavePath}
+		torrentInfoLabels := []string{labelName, torrentLabelCategory, torrentLabelState, torrentLabelSize, torrentLabelProgress, labelSeeders, torrentLabelLeechers, torrentLabelDlSpeed, torrentLabelUpSpeed, torrentLabelAmountLeft, torrentLabelTimeActive, torrentLabelEta, torrentLabelUploaded, torrentLabelUploadedSession, labelDownloaded, torrentLabelDownloadedSession, torrentLabelMaxRatio, torrentLabelRatio, torrentLabelTracker, torrentLabelAddedOn, torrentLabelComment, torrentLabelCompletionOn, torrentLabelSavePath}
 		if app.Exporter.ExperimentalFeatures.EnableLabelWithHash {
 			torrentInfoLabels = append(torrentInfoLabels, torrentLabelHash)
 		}
@@ -271,7 +271,7 @@ func Torrent(result *API.Info, webUIVersion *string, r *prometheus.Registry) {
 		metrics[torrentSessionUploaded].With(torrentLabels).Set(float64(torrent.UploadedSession))
 		metrics[torrentTotalDownloaded].With(torrentLabels).Set(float64(torrent.Downloaded))
 		metrics[torrentTotalUploaded].With(torrentLabels).Set(float64(torrent.Uploaded))
-		metrics[torrentCompletedOn].With(torrentLabels).Set(float64(torrent.CompletedOn))
+		metrics[torrentCompletionOn].With(torrentLabels).Set(float64(torrent.CompletionOn))
 		metrics[torrentAddedOn].With(torrentLabels).Set(float64(torrent.AddedOn))
 
 		if app.Exporter.Features.EnableIncreasedCardinality {
@@ -320,7 +320,7 @@ func Torrent(result *API.Info, webUIVersion *string, r *prometheus.Registry) {
 				torrentLabelComment:           torrent.Comment,
 				torrentLabelSavePath:          torrentSavePath,
 				torrentLabelAddedOn:           torrentAddedOn,
-				torrentLabelCompletedOn:       torrentCompletedOn,
+				torrentLabelCompletionOn:      torrentCompletionOn,
 			}
 			if app.Exporter.ExperimentalFeatures.EnableLabelWithHash {
 				infoLabels[torrentLabelHash] = torrent.Hash

--- a/src/prometheus/prometheus.go
+++ b/src/prometheus/prometheus.go
@@ -175,10 +175,14 @@ func Torrent(result *API.Info, webUIVersion *string, r *prometheus.Registry) {
 	if app.Exporter.ExperimentalFeatures.EnableLabelWithHash {
 		labels = append(labels, torrentLabelHash)
 	}
-	labelsWithTag := append(labels, torrentLabelTag)
-	labelsWithComment := append(labels, torrentLabelComment)
-	labelsWithState := append(labels, torrentLabelState)
-	labelsWithSavePath := append(labels, torrentLabelSavePath)
+	labelsWithTag := append([]string{}, labels...)
+	labelsWithTag = append(labelsWithTag, torrentLabelTag)
+	labelsWithComment := append([]string{}, labels...)
+	labelsWithComment = append(labelsWithComment, torrentLabelComment)
+	labelsWithState := append([]string{}, labels...)
+	labelsWithState = append(labelsWithState, torrentLabelState)
+	labelsWithSavePath := append([]string{}, labels...)
+	labelsWithSavePath = append(labelsWithSavePath, torrentLabelSavePath)
 
 	gauges := Gauge{
 		{&torrentEta, &Seconds, "The current ETA for each torrent", &labels},
@@ -347,13 +351,13 @@ func Torrent(result *API.Info, webUIVersion *string, r *prometheus.Registry) {
 
 func Preference(result *API.Preferences, r *prometheus.Registry) {
 	gauges := GaugeSet{
-		{"max_active_downloads", nil, "The max number of downloads allowed", float64((*result).MaxActiveDownloads)},
-		{"max_active_uploads", nil, "The max number of active uploads allowed", float64((*result).MaxActiveUploads)},
-		{"max_active_torrents", nil, "The max number of active torrents allowed", float64((*result).MaxActiveTorrents)},
-		{"download_rate_limit", &Bytes, "The global download rate limit", float64((*result).DlLimit)},
-		{"upload_rate_limit", &Bytes, "The global upload rate limit", float64((*result).UpLimit)},
-		{"alt_download_rate_limit", &Bytes, "The alternate download rate limit", float64((*result).AltDlLimit)},
-		{"alt_upload_rate_limit", &Bytes, "The alternate upload rate limit", float64((*result).AltUpLimit)},
+		{"max_active_downloads", nil, "The max number of downloads allowed", float64(result.MaxActiveDownloads)},
+		{"max_active_uploads", nil, "The max number of active uploads allowed", float64(result.MaxActiveUploads)},
+		{"max_active_torrents", nil, "The max number of active torrents allowed", float64(result.MaxActiveTorrents)},
+		{"download_rate_limit", &Bytes, "The global download rate limit", float64(result.DlLimit)},
+		{"upload_rate_limit", &Bytes, "The global upload rate limit", float64(result.UpLimit)},
+		{"alt_download_rate_limit", &Bytes, "The alternate download rate limit", float64(result.AltDlLimit)},
+		{"alt_upload_rate_limit", &Bytes, "The alternate upload rate limit", float64(result.AltUpLimit)},
 	}
 
 	registerGaugeGlobalAndSet(&gauges, r)
@@ -445,10 +449,10 @@ func Trackers(result []*API.Trackers, r *prometheus.Registry) {
 }
 
 func MainData(result *API.MainData, r *prometheus.Registry) {
-	globalratio, err := strconv.ParseFloat((*result).ServerState.GlobalRatio, 64)
+	globalratio, err := strconv.ParseFloat(result.ServerState.GlobalRatio, 64)
 
 	if err != nil {
-		logger.Log.Warn(fmt.Sprintf("error to convert ratio \"%s\"", (*result).ServerState.GlobalRatio))
+		logger.Log.Warn(fmt.Sprintf("error to convert ratio \"%s\"", result.ServerState.GlobalRatio))
 	} else {
 		qbittorrentGlobalRatio := prometheus.NewGauge(prometheus.GaugeOpts{
 			Name: createMetricName(metricNameGlobal, "ratio"),
@@ -459,7 +463,7 @@ func MainData(result *API.MainData, r *prometheus.Registry) {
 
 	}
 	useAltSpeedLimits := 0.0
-	if (*result).ServerState.UseAltSpeedLimits {
+	if result.ServerState.UseAltSpeedLimits {
 		useAltSpeedLimits = 1.0
 	}
 	qbittorrentAppAltRateLimitsEnabled := prometheus.NewGauge(prometheus.GaugeOpts{
@@ -470,12 +474,12 @@ func MainData(result *API.MainData, r *prometheus.Registry) {
 	qbittorrentAppAltRateLimitsEnabled.Set(float64(useAltSpeedLimits))
 
 	gauges := GaugeSet{
-		{"alltime_downloaded", &Bytes, "The all-time total download amount of torrents", float64((*result).ServerState.AlltimeDl)},
-		{"alltime_uploaded", &Bytes, "The all-time total upload amount of torrents", float64((*result).ServerState.AlltimeUl)},
-		{"session_downloaded", &Bytes, "The total download amount of torrents for this session", float64((*result).ServerState.DlInfoData)},
-		{"session_uploaded", &Bytes, "The total upload amount of torrents for this session", float64((*result).ServerState.UpInfoData)},
-		{"download_speed", &Bytes, "The current download speed of all torrents", float64((*result).ServerState.DlInfoSpeed)},
-		{"upload_speed", &Bytes, "The total current upload speed of all torrents", float64((*result).ServerState.UpInfoSpeed)},
+		{"alltime_downloaded", &Bytes, "The all-time total download amount of torrents", float64(result.ServerState.AlltimeDl)},
+		{"alltime_uploaded", &Bytes, "The all-time total upload amount of torrents", float64(result.ServerState.AlltimeUl)},
+		{"session_downloaded", &Bytes, "The total download amount of torrents for this session", float64(result.ServerState.DlInfoData)},
+		{"session_uploaded", &Bytes, "The total upload amount of torrents for this session", float64(result.ServerState.UpInfoData)},
+		{"download_speed", &Bytes, "The current download speed of all torrents", float64(result.ServerState.DlInfoSpeed)},
+		{"upload_speed", &Bytes, "The total current upload speed of all torrents", float64(result.ServerState.UpInfoSpeed)},
 	}
 
 	registerGaugeGlobalAndSet(&gauges, r)
@@ -485,7 +489,7 @@ func MainData(result *API.MainData, r *prometheus.Registry) {
 		Help: "All tags used in qbittorrent",
 	}, []string{torrentLabelTag})
 	r.MustRegister(qbittorrentGlobalTags)
-	if len((*result).Tags) > 0 {
+	if len(result.Tags) > 0 {
 		for _, tag := range result.Tags {
 			labels := prometheus.Labels{
 				torrentLabelTag: tag,

--- a/src/prometheus/prometheus.go
+++ b/src/prometheus/prometheus.go
@@ -274,18 +274,19 @@ func Torrent(result *API.Info, webUIVersion *string, r *prometheus.Registry) {
 		metrics[torrentCompletedOn].With(torrentLabels).Set(float64(torrent.CompletedOn))
 		metrics[torrentAddedOn].With(torrentLabels).Set(float64(torrent.AddedOn))
 
-		tagComment := prometheus.Labels{labelName: torrent.Name, torrentLabelComment: torrent.Comment}
-		tagState := prometheus.Labels{labelName: torrent.Name, torrentLabelState: torrent.State}
-		tagSavePath := prometheus.Labels{labelName: torrent.Name, torrentLabelSavePath: torrent.SavePath}
-		if app.Exporter.ExperimentalFeatures.EnableLabelWithHash {
-			tagState[torrentLabelHash] = torrent.Hash
-			tagSavePath[torrentLabelHash] = torrent.Hash
-			tagComment[torrentLabelHash] = torrent.Hash
+		if app.Exporter.Features.EnableIncreasedCardinality {
+			tagComment := prometheus.Labels{labelName: torrent.Name, torrentLabelComment: torrent.Comment}
+			tagState := prometheus.Labels{labelName: torrent.Name, torrentLabelState: torrent.State}
+			tagSavePath := prometheus.Labels{labelName: torrent.Name, torrentLabelSavePath: torrent.SavePath}
+			if app.Exporter.ExperimentalFeatures.EnableLabelWithHash {
+				tagState[torrentLabelHash] = torrent.Hash
+				tagSavePath[torrentLabelHash] = torrent.Hash
+				tagComment[torrentLabelHash] = torrent.Hash
+			}
+			metrics[torrentState].With(tagState).Set(1.0)
+			metrics[torrentSavePath].With(tagSavePath).Set(1.0)
+			metrics[torrentComment].With(tagComment).Set(1.0)
 		}
-
-		metrics[torrentState].With(tagState).Set(1.0)
-		metrics[torrentSavePath].With(tagSavePath).Set(1.0)
-		metrics[torrentComment].With(tagComment).Set(1.0)
 
 		_, exists := countStates[torrent.State]
 		if exists {

--- a/src/prometheus/prometheus_test.go
+++ b/src/prometheus/prometheus_test.go
@@ -197,7 +197,7 @@ func TestTorrent(t *testing.T) {
 			State:             "stalledUP",
 			Tags:              "tag1, tag2",
 			AddedOn:           1664715487,
-			CompletedOn:       1664719487,
+			CompletionOn:      1664719487,
 		},
 	}
 

--- a/src/prometheus/prometheus_test.go
+++ b/src/prometheus/prometheus_test.go
@@ -196,6 +196,8 @@ func TestTorrent(t *testing.T) {
 			Uploaded:          500000000,
 			State:             "stalledUP",
 			Tags:              "tag1, tag2",
+			AddedOn:           1664715487,
+			CompletedOn:       1664719487,
 		},
 	}
 
@@ -221,6 +223,8 @@ func TestTorrent(t *testing.T) {
 		"qbittorrent_torrent_total_downloaded_bytes":   1000000000,
 		"qbittorrent_torrent_total_uploaded_bytes":     500000000,
 		"qbittorrent_global_torrents":                  1,
+		"qbittorrent_torrent_added_on":                 1664715487,
+		"qbittorrent_torrent_completed_on":             1664719487,
 	}
 
 	testMetrics(expectedMetrics, registry, t)


### PR DESCRIPTION
New metrics enabled by default:
- `qbittorrent_torrent_added_on`: label=name (+hash) / value=timestamp
- `qbittorrent_torrent_completed_on`: label=name (+hash) / value=timestamp

New metrics disabled by default, enabled with `ENABLE_INCREASED_CARDINALITY`:
- `qbittorrent_torrent_save_path`: label=name+save_path (+hash) / value=1
- `qbittorrent_torrent_state`: label=name+state (+hash) / value=1
- `qbittorrent_torrent_comment`: label=name+comment (+hash) / value=1