### PR TITLE
feat: add healthz endpoint for probes without metrics collection

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,10 @@ You can find in the dashboard the following metrics:
 - Tags
 - Trackers
 
+## Health check
+
+The exporter exposes a `/healthz` endpoint that returns `200 OK` without querying qBittorrent. Use it for Docker or Kubernetes liveness and readiness probes: probing the metrics path triggers a full collection on each hit, which is expensive with a large number of torrents. `/healthz` is not protected by basic auth.
+
 ## Resources
 
 This app uses ~20 times less RAM compared to the [original exporter](https://github.com/caseyscarborough/qbittorrent-exporter) for the same amount of torrents.

--- a/main.go
+++ b/main.go
@@ -29,6 +29,8 @@ func main() {
 
 	http.HandleFunc(app.Exporter.Path, metrics)
 
+	http.HandleFunc("/healthz", healthz)
+
 	http.HandleFunc("/", func(w http.ResponseWriter, req *http.Request) {
 		http.Redirect(w, req, app.Exporter.Path, http.StatusFound)
 	})
@@ -66,6 +68,12 @@ func metrics(w http.ResponseWriter, req *http.Request, allRequestsFunc func(*vmm
 	} else {
 		metricsSet.WritePrometheus(w)
 	}
+}
+
+// healthz reports server liveness without triggering a metrics collection.
+func healthz(w http.ResponseWriter, _ *http.Request) {
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write([]byte("OK"))
 }
 
 func basicAuth(h http.HandlerFunc) http.HandlerFunc {

--- a/main_test.go
+++ b/main_test.go
@@ -87,6 +87,24 @@ func TestMetricsReturnMetric(t *testing.T) {
 	}
 }
 
+func TestHealthzReturnsOK(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	req := httptest.NewRequestWithContext(ctx, http.MethodGet, "/healthz", nil)
+	rec := httptest.NewRecorder()
+
+	healthz(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("expected status code 200, got %d", rec.Code)
+	}
+
+	if rec.Body.String() != "OK" {
+		t.Errorf("expected body 'OK', got %s", rec.Body.String())
+	}
+}
+
 func TestBasicAuth_Success(t *testing.T) {
 	buff.Reset()
 


### PR DESCRIPTION
Adds a `/healthz` endpoint that returns `200 OK` without querying qBittorrent, plus a test and a README note.

Currently every path triggers a full collection: the catch-all redirects to the metrics path, and Kubernetes httpGet probes follow same-host redirects. With per-torrent options enabled and a large instance, one collection fans out to hundreds of qBittorrent API calls, making liveness and readiness probes expensive. The endpoint skips the basic auth wrapper so orchestrators can probe without credentials.